### PR TITLE
`order` not in scope

### DIFF
--- a/docs/guides/unit-testing.md
+++ b/docs/guides/unit-testing.md
@@ -16,6 +16,7 @@ const instances = ({ env }) => ({
 });
 
 exports.app = async (event, { orderRepository }) => {
+  const order = event;
   await orderRepository.save(order);
 };
 


### PR DESCRIPTION
There are different options here. Either rename the `event` parameter to `order` or alias it.