### PR TITLE
`order` not in scope

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -52,6 +52,7 @@ const instances = ({ env }) => ({
 // Your application core, which is cloud agnostic
 // Dependencies made available via destructuring
 const app = async (input, { orderRepository, idGenerator }) => {
+  const order = input;
   await orderRepository.save(order);
 };
 


### PR DESCRIPTION
There are different options here. Either rename the `input` parameter to `order` or alias it.