### PR TITLE
Fix Using built-in adapter example typo

### DIFF
--- a/docs/guides/creating-api-endpoints.md
+++ b/docs/guides/creating-api-endpoints.md
@@ -116,7 +116,7 @@ const apigateway = adapterApi.apigateway({
   inputType: "body",
   errorMappings: {
     ".*": error => ({
-      body: { error: { message: err.message } },
+      body: { error: { message: error.message } },
       statusCode: 500
     })
   }


### PR DESCRIPTION
The name of `error` var at 'Using built-in adapter' was `err`