### PR TITLE
Fix syntax error in core concepts docs

### DIFF
--- a/docs/introduction/core-concepts.md
+++ b/docs/introduction/core-concepts.md
@@ -57,7 +57,7 @@ const adapter = app => (event, dependencies) =>
 const handler = adapter => (event, context, callback) =>
   adapter(event, createDependencies());
 
-const handler = handler(adapter(app));
+exports.handler = handler(adapter(app));
 ```
 
 You now have different functions, each of them with a clear responsibility. It


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7361428/159473043-fbec7b76-77ce-49ac-b692-3c6e9ea5e80a.png)

The syntax error on this bit of the docs makes understanding what is going on here harder. 

Hopefully fixes issue #10 